### PR TITLE
Sharpen Iron Petal runner pacing and feedback

### DIFF
--- a/docs/spec/game/generation-pipeline.md
+++ b/docs/spec/game/generation-pipeline.md
@@ -64,6 +64,11 @@ embedded contract in this same change.
 Runner planning refuses an image model outside the verified GPT Image 2 native-alpha model
 family before graph execution. Its generative loop node additionally requires the route's
 `masked_edit` capability; a binding that only advertises reference images cannot plan that node.
+Runner soundtrack nodes compile the shared soundtrack contract together with a recipe-owned
+`soundtrack_direction`: the first beat establishes the rhythmic engine, short action cells and
+clear transients sustain forward motion, and RPG exploration, town-theme, pastoral, cinematic,
+rubato, ambient, and long-form orchestral development are excluded. Planning and execution use
+the same compiled direction, so this genre input is part of the provider node's cache identity.
 
 `stage-gen generate` requires `--input` pointing to a prepared directory or ZIP whose root
 contains `game.toml`. There is no bare-prompt fallback. The runner recipe is a single-shot graph:

--- a/docs/spec/game/runner.md
+++ b/docs/spec/game/runner.md
@@ -83,6 +83,13 @@ pacing shapes only feel and stays in the consumer. Scoring is runtime-owned:
 distance plus pickups, with a chain multiplier that breaks on a missed
 pickup.
 
+Speed names currently include `steady_runner_v1` (6 columns per second, 1.5x
+cap) and `brisk_runner_v1` (7.5 columns per second, the same proved 1.5x cap).
+Ramp names currently include `gentle_ramp_v1`, which earns its bonus over
+1,800 columns, and `brisk_ramp_v1`, which earns the same bonus over 720
+columns. Separate names preserve existing package feel while a faster package
+opts into both the new admission arithmetic and consumer pacing.
+
 Jump names: `single_arc_v1`, and `double_arc_v1`, whose air jump is **recovery,
 never reach** - it declares the identical single-hop admission arithmetic, so
 no authored chunk ever demands both hops, a player who spends the air jump
@@ -232,10 +239,14 @@ A future generated-file realization extends the effect side without changing
 the stable event bindings.
 
 Music remains the separate optional `runner/soundtrack.toml` catalog and uses
-the existing provider-neutral `game-soundtrack-v1` generation path. The runtime
-shuffles its declared loop-ready tracks after audio unlock. Do not let a tempo
-field into `game-soundtrack-v1`: it is shared across genres, and the other
-genres have no tempo.
+the existing provider-neutral `game-soundtrack-v1` generation path. The runner
+recipe adds genre staging to the authored brief: the rhythmic engine begins on
+the first beat, short action cells and clear transients preserve forward
+motion, and exploration, town-theme, pastoral, cinematic, rubato, ambient, and
+long-form orchestral development are explicitly excluded. The runtime shuffles
+its declared loop-ready tracks after audio unlock. Do not let a tempo field into
+`game-soundtrack-v1`: it is shared across genres, and the other genres have no
+tempo; a runner author expresses BPM inside the creative brief.
 
 ## Runtime composition
 

--- a/library/games/iron-petal-unit/game.toml
+++ b/library/games/iron-petal-unit/game.toml
@@ -1,7 +1,7 @@
 schema_version = 9
 kind = "game-contract-v9"
 game_id = "iron-petal-unit"
-revision = 1
+revision = 2
 display_name = "Iron Petal Unit"
 
 [universe]

--- a/library/games/iron-petal-unit/runner/content/items.toml
+++ b/library/games/iron-petal-unit/runner/content/items.toml
@@ -1,7 +1,7 @@
 schema_version = 2
 kind = "item-content-v2"
 game_id = "iron-petal-unit"
-revision = 1
+revision = 2
 
 [[references]]
 reference_id = "cover_seed_cell"
@@ -13,7 +13,7 @@ rights_basis = ["Original AI-generated Iron Petal Unit cover approved for redist
 [[items]]
 item_id = "lumen_seed"
 height_units = 0.28
-display_name = "Lumen Seed Cell"
+display_name = "Coin"
 item_kind = "currency"
 reference_ids = ["cover_seed_cell"]
-prompt = "One original luminous greenhouse seed cell: a small mint-glowing oval capsule held by four cream-and-coral petal fins, one simple flower aperture and no face, text, number, emblem, logo, or watermark; clean high-contrast collectible icon, strict side view, isolated on native transparent background with generous margins."
+prompt = "One regular round gold coin, immediately recognizable as ordinary video-game currency: a simple solid circular face, raised outer rim, and one subtle inset circle. No seed, flower, gem, capsule, character, symbol, text, number, logo, ornate motif, unusual silhouette, or invented object. Apply only the Iron Petal Unit art direction through warm cream-gold metal, restrained coral edge highlights, clean high-contrast ceramic-toy rendering, and slight three-quarter side view. Keep the conventional coin shape readable at 40-pixel gameplay size; one coin only, isolated on native transparent background with generous margins."

--- a/library/games/iron-petal-unit/runner/gameplay.toml
+++ b/library/games/iron-petal-unit/runner/gameplay.toml
@@ -1,14 +1,14 @@
 schema_version = 2
 kind = "runner-gameplay-v2"
 game_id = "iron-petal-unit"
-revision = 1
+revision = 2
 track_id = "halcyon-rescue-line"
 
 [run]
-speed_profile = "steady_runner_v1"
+speed_profile = "brisk_runner_v1"
 jump_profile = "double_arc_v1"
 collision_policy = "end_run_v1"
 duck_profile = "slide_v1"
 
 [ramp]
-profile = "gentle_ramp_v1"
+profile = "brisk_ramp_v1"

--- a/library/games/iron-petal-unit/runner/soundtrack.toml
+++ b/library/games/iron-petal-unit/runner/soundtrack.toml
@@ -1,7 +1,7 @@
 schema_version = 1
 kind = "game-soundtrack-v1"
 game_id = "iron-petal-unit"
-revision = 1
+revision = 2
 
 [playback]
 selection = "shuffle"
@@ -10,7 +10,7 @@ no_immediate_repeat = true
 [[tracks]]
 track_id = "glasshouse_rescue"
 display_name = "Glasshouse Rescue"
-creative_brief = "An original optimistic orbital-greenhouse runner instrumental with nimble marimba, warm analog pulses, pizzicato strings, brushed hand percussion, airy woodwind, and a bright mint-like bell color; forward-moving and heroic without becoming aggressive, with no recognizable melody and no vocals."
+creative_brief = "A fast original orbital-greenhouse endless-runner instrumental at 156 BPM in steady 4/4: immediate syncopated electronic drums, crisp ceramic clicks, a driving rounded synth-bass ostinato, compact marimba-pluck figures, and short mint-bright bell responses. Sustain athletic forward propulsion for rapid jumps, slides, pickups, and score chasing from the first beat; use short loopable phrases and energetic transients without becoming harsh. Avoid pastoral woodwind, pizzicato quest music, orchestral adventure swells, town-theme warmth, cinematic exploration, rubato, ambient breakdowns, or long pads. No recognizable melody and no vocals."
 
 [tracks.generation]
 intent = "generate"
@@ -21,7 +21,7 @@ target_duration_seconds = 90
 [[tracks]]
 track_id = "petal_reactor"
 display_name = "Petal Reactor"
-creative_brief = "An original playful mechanical-botanical runner instrumental: rounded synth bass, light ceramic percussion, plucked strings, soft brass swells, small sparkling chimes, and buoyant rescue-adventure momentum; colorful and never frantic, with no recognizable melody and no vocals. HARD LOOP CONTRACT: the first and last bars must share the same beat phase, bass energy, percussion pattern, musical density, and room tone so end-to-start playback is attention-free; no intro, outro, cadence, drum fill, riser, crash, held final chord, fade, or exposed reverb tail."
+creative_brief = "A high-energy original mechanical-botanical endless-runner instrumental at 164 BPM in steady 4/4: a punchy electronic breakbeat, crisp ceramic percussion, propulsive rounded synth bass, rapid muted pluck ostinatos, and tiny sparkling reactor-chime accents. Keep constant kinetic momentum for fast obstacle reactions and escalating score play, with compact two- and four-bar cells, strong downbeats, and no soft exploration passage. Avoid RPG quest scoring, orchestral brass swells, pastoral strings or woodwind, town-theme sentiment, cinematic development, rubato, ambient breakdowns, or long pads. No recognizable melody and no vocals. HARD LOOP CONTRACT: the first and last bars must share the same beat phase, bass energy, percussion pattern, musical density, and room tone so end-to-start playback is attention-free; no intro, outro, cadence, drum fill, riser, crash, held final chord, fade, or exposed reverb tail."
 
 [tracks.generation]
 intent = "generate"

--- a/src/stage_gen/components/runner_gameplay/models.py
+++ b/src/stage_gen/components/runner_gameplay/models.py
@@ -35,11 +35,11 @@ from stage_gen.components._game_input import (
 
 RUNNER_GAMEPLAY_SCHEMA_VERSION = 2
 
-SpeedProfileName = Literal["steady_runner_v1"]
+SpeedProfileName = Literal["steady_runner_v1", "brisk_runner_v1"]
 JumpProfileName = Literal["single_arc_v1", "double_arc_v1"]
 CollisionPolicy = Literal["end_run_v1"]
 DuckProfileName = Literal["slide_v1"]
-RampProfile = Literal["gentle_ramp_v1"]
+RampProfile = Literal["gentle_ramp_v1", "brisk_ramp_v1"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,6 +61,7 @@ class SpeedProfile:
 
 SPEED_PROFILES: Final[dict[str, SpeedProfile]] = {
     "steady_runner_v1": SpeedProfile(base_speed_columns_per_second=6.0, max_speed_multiplier=1.5),
+    "brisk_runner_v1": SpeedProfile(base_speed_columns_per_second=7.5, max_speed_multiplier=1.5),
 }
 
 

--- a/src/stage_gen/recipes/sideview_runner/prepared_runner.py
+++ b/src/stage_gen/recipes/sideview_runner/prepared_runner.py
@@ -126,6 +126,7 @@ from stage_gen.recipes.sideview_runner.runner_graph import (
 )
 from stage_gen.recipes.sideview_runner.runner_prompts import (
     layer_loop_prompt,
+    soundtrack_direction,
     visual_direction_digest,
 )
 from stage_gen.recipes.sideview_runner.runner_types import (
@@ -2074,6 +2075,7 @@ class SideviewRunnerNodeHandler:
                 track_id=track.track_id,
                 creative_brief=track.creative_brief,
                 generation=track.generation,
+                direction=soundtrack_direction(),
             )
         raise ValueError(f"provider node {node.node_id} carries no executable prompt")
 

--- a/src/stage_gen/recipes/sideview_runner/runner_graph.py
+++ b/src/stage_gen/recipes/sideview_runner/runner_graph.py
@@ -54,6 +54,7 @@ from stage_gen.recipes.sideview_runner.runner_prompts import (
     ground_prompt,
     layer_loop_prompt,
     layer_prompt,
+    soundtrack_direction,
     structural_ground_prompt,
     visual_direction_digest,
 )
@@ -789,6 +790,7 @@ def build_runner_execution_graph(
                     track_id=audio_track.track_id,
                     creative_brief=audio_track.creative_brief,
                     generation=audio_track.generation,
+                    direction=soundtrack_direction(),
                 )
                 generate_id = f"soundtrack-{track_id}-generate"
                 generated = builder.add(

--- a/src/stage_gen/recipes/sideview_runner/runner_prompts.py
+++ b/src/stage_gen/recipes/sideview_runner/runner_prompts.py
@@ -209,6 +209,18 @@ def catalog_asset_prompt(resolved: ResolvedRunnerPackage, *, family: str, prompt
     )
 
 
+def soundtrack_direction() -> str:
+    """The runner-specific staging omitted by the shared music compiler."""
+
+    return (
+        "Endless-runner staging: establish the full rhythmic engine on the first beat and "
+        "maintain an urgent, even forward pulse throughout. Favor short repeating action cells, "
+        "clear percussion transients, and bass motion that supports rapid player reactions. "
+        "Do not drift into RPG exploration, town-theme, pastoral, cinematic, rubato, ambient, "
+        "or long-form orchestral development."
+    )
+
+
 __all__ = [
     "avatar_concept_prompt",
     "avatar_motion_prompt",
@@ -217,6 +229,7 @@ __all__ = [
     "layer_loop_prompt",
     "layer_prompt",
     "structural_ground_prompt",
+    "soundtrack_direction",
     "visual_direction",
     "visual_direction_digest",
 ]

--- a/tests/unit/recipes/sideview_runner/test_manifest_gameplay.py
+++ b/tests/unit/recipes/sideview_runner/test_manifest_gameplay.py
@@ -55,6 +55,19 @@ def test_the_published_gameplay_block_is_exactly_the_parsers_contract() -> None:
     }
 
 
+def test_the_brisk_profiles_publish_their_proved_speed_and_runtime_ramp_names() -> None:
+    brisk = GAMEPLAY.replace(
+        b'speed_profile = "steady_runner_v1"', b'speed_profile = "brisk_runner_v1"'
+    ).replace(b'profile = "gentle_ramp_v1"', b'profile = "brisk_ramp_v1"')
+
+    block = manifest_gameplay(load_runner_gameplay_bytes(brisk))
+
+    assert block["speed_profile"] == "brisk_runner_v1"
+    assert block["ramp_profile"] == "brisk_ramp_v1"
+    assert block["base_speed_columns_per_second"] == 7.5
+    assert block["max_speed_multiplier"] == 1.5
+
+
 def test_a_duckless_gameplay_publishes_null_duck_arithmetic() -> None:
     duckless = GAMEPLAY.replace(b'duck_profile = "slide_v1"\n', b"")
     block = manifest_gameplay(load_runner_gameplay_bytes(duckless))

--- a/tests/unit/recipes/sideview_runner/test_runner_recipe.py
+++ b/tests/unit/recipes/sideview_runner/test_runner_recipe.py
@@ -192,6 +192,19 @@ def test_soundtrack_generation_keys_the_complete_provider_prompt(tmp_path: Path)
     assert first.cache_key != second.cache_key
 
 
+def test_soundtrack_generation_adds_runner_specific_kinetic_staging(tmp_path: Path) -> None:
+    node = (
+        _executor()
+        .plan(two_genre_package(tmp_path))
+        .graph.node("soundtrack-sunpetal_sprint-generate")
+    )
+
+    assert node.card is not None and node.card.prompt is not None
+    assert "Endless-runner staging" in node.card.prompt
+    assert "full rhythmic engine on the first beat" in node.card.prompt
+    assert "Do not drift into RPG exploration" in node.card.prompt
+
+
 def test_ground_validation_keys_the_topology_lookup_resource(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/web/lib/sideview-runner/contract.test.ts
+++ b/web/lib/sideview-runner/contract.test.ts
@@ -42,6 +42,21 @@ describe("parseRunnerRuntimeManifest", () => {
     expect(Object.isFrozen(manifest.segments.chunks[0])).toBe(true);
   });
 
+  test("accepts the brisk speed and ramp names with their published arithmetic", () => {
+    const document = validRunnerManifest();
+    const gameplay = document.gameplay as Record<string, unknown>;
+    gameplay.speed_profile = "brisk_runner_v1";
+    gameplay.ramp_profile = "brisk_ramp_v1";
+    gameplay.base_speed_columns_per_second = 7.5;
+
+    const manifest = parseRunnerRuntimeManifest(document);
+
+    expect(manifest.gameplay.speedProfile).toBe("brisk_runner_v1");
+    expect(manifest.gameplay.rampProfile).toBe("brisk_ramp_v1");
+    expect(manifest.gameplay.baseSpeedColumnsPerSecond).toBe(7.5);
+    expect(manifest.gameplay.maxSpeedMultiplier).toBe(1.5);
+  });
+
   test("parses structural ground locked one-for-one to authored segment grids", () => {
     const document = validRunnerManifest();
     document.ground = {

--- a/web/lib/sideview-runner/contract.ts
+++ b/web/lib/sideview-runner/contract.ts
@@ -219,11 +219,11 @@ export interface RunnerRuntimeManifest {
   readonly camera: { readonly mode: "auto_run_x_v1" };
   readonly scale: { readonly playerHeightTiles: number; readonly tilePx: number };
   readonly gameplay: {
-    readonly speedProfile: "steady_runner_v1";
+    readonly speedProfile: "steady_runner_v1" | "brisk_runner_v1";
     readonly jumpProfile: "single_arc_v1" | "double_arc_v1";
     readonly collisionPolicy: "end_run_v1";
     readonly duckProfile: "slide_v1" | null;
-    readonly rampProfile: "gentle_ramp_v1";
+    readonly rampProfile: "gentle_ramp_v1" | "brisk_ramp_v1";
     readonly maxClearGapColumns: number;
     readonly maxRiseTiles: number;
     /** The published arc arithmetic: the same closed forms admission proved. */
@@ -875,6 +875,7 @@ export function parseRunnerRuntimeManifest(value: unknown): RunnerRuntimeManifes
     gameplay: Object.freeze({
       speedProfile: literal(rawGameplay.speed_profile, "gameplay.speed_profile", [
         "steady_runner_v1",
+        "brisk_runner_v1",
       ]),
       jumpProfile: literal(rawGameplay.jump_profile, "gameplay.jump_profile", [
         "single_arc_v1",
@@ -887,7 +888,10 @@ export function parseRunnerRuntimeManifest(value: unknown): RunnerRuntimeManifes
         rawGameplay.duck_profile === null || rawGameplay.duck_profile === undefined
           ? null
           : literal(rawGameplay.duck_profile, "gameplay.duck_profile", ["slide_v1"]),
-      rampProfile: literal(rawGameplay.ramp_profile, "gameplay.ramp_profile", ["gentle_ramp_v1"]),
+      rampProfile: literal(rawGameplay.ramp_profile, "gameplay.ramp_profile", [
+        "gentle_ramp_v1",
+        "brisk_ramp_v1",
+      ]),
       maxClearGapColumns: boundedInteger(
         rawGameplay.max_clear_gap_columns,
         "gameplay.max_clear_gap_columns",

--- a/web/lib/sideview-runner/difficulty.test.ts
+++ b/web/lib/sideview-runner/difficulty.test.ts
@@ -10,6 +10,7 @@ import { runnerManifestFixture } from "./fixture";
 import { createRunnerWorld } from "./world";
 
 const gentle = rampProfile("gentle_ramp_v1");
+const brisk = rampProfile("brisk_ramp_v1");
 
 function manifestWithDifficultyBand(): ReturnType<typeof parseRunnerRuntimeManifest> {
   const document = runnerManifestFixture();
@@ -59,6 +60,14 @@ describe("speedMultiplier", () => {
       expect(value).toBeGreaterThanOrEqual(previous);
       previous = value;
     }
+  });
+
+  test("the brisk profile earns the same proved cap during an opening run", () => {
+    expect(brisk.maxSpeedBonus).toBe(gentle.maxSpeedBonus);
+    expect(brisk.speedRampColumns).toBe(720);
+    expect(brisk.speedRampColumns).toBeLessThan(gentle.speedRampColumns);
+    expect(speedMultiplier(brisk, 360)).toBeCloseTo(1.25, 10);
+    expect(speedMultiplier(brisk, 720)).toBeCloseTo(1.5, 10);
   });
 });
 

--- a/web/lib/sideview-runner/difficulty.ts
+++ b/web/lib/sideview-runner/difficulty.ts
@@ -1,6 +1,6 @@
 // The ramp: distance into a difficulty band and speed, per named profile.
 //
-// The manifest names the feel ("gentle_ramp_v1"); this consumer owns the
+// The manifest names the feel (for example "gentle_ramp_v1"); this consumer owns the
 // numbers, the same division of labor the generation side uses for its
 // experience curve. Both curves are pure functions of distance so a replayed
 // seed meets exactly the chunks and speeds it met the first time.
@@ -14,7 +14,7 @@
 import type { GameSystem } from "./systems";
 import type { RunnerWorld } from "./world";
 
-export type RampProfileName = "gentle_ramp_v1";
+export type RampProfileName = "gentle_ramp_v1" | "brisk_ramp_v1";
 
 export interface RampProfile {
   /** Columns of running that raise the difficulty ceiling by one. */
@@ -42,6 +42,16 @@ const RAMP_PROFILES: Readonly<Record<RampProfileName, RampProfile>> = Object.fre
     restEveryAppends: 6,
     maxSpeedBonus: 0.5,
     speedRampColumns: 1800,
+  }),
+  // Brisk: preserve the proved 1.5x cap but earn it during the opening
+  // score-chase minute instead of after a several-minute survival run.
+  brisk_ramp_v1: Object.freeze({
+    columnsPerCeilingStep: 60,
+    maxCeiling: 10,
+    minCeilingLag: 3,
+    restEveryAppends: 6,
+    maxSpeedBonus: 0.5,
+    speedRampColumns: 720,
   }),
 });
 


### PR DESCRIPTION
Summary:
- add an opt-in brisk runner profile: 7.5 columns/sec start, 1.5x cap, reached over 720 columns
- make the currency pickup a conventional round gold coin while retaining the package art direction
- add runner-specific soundtrack staging and retune both authored tracks away from RPG/exploration character
- document and test the new generation/runtime contracts

Verification:
- full Python gate: 1161 passed, 6 deselected; docs/build/CLI gates passed
- web tests: 992 passed
- strict TypeScript and production webpack build passed
- canonical package validation passed (21 files)
- scoped v8 live generation passed: 1 image generation, 0 music regeneration, 0 structured generation
- exact v8 browser play-test passed: jump, brisk scrolling, coin readability, MP3 HTTP 200, zero warnings/errors
- independent native audio-input listening review passed both revised tracks for runner fit, non-RPG character, and loop seams

Continues #4.